### PR TITLE
Add NewRelic deployment notification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,43 @@ hipchat:
     - '123456'
 ```
 
+### NewRelic
+If [NewRelic deployment notifications](https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/deployment-notifications) are desired you need to 
+both supply your [NewRelic REST API key](https://docs.newrelic.com/docs/apis/rest-api-v2/requirements/api-keys) (NOT the license key given to the agent) and set the `NEW_RELIC_APP_NAME` environment variable on the service:
+
+*globals.yml*
+```
+newrelic:
+  token: 'i_am_an_api_token'
+```
+
+*myservice.yml*
+```
+override:
+  env:
+    NEW_RELIC_APP_NAME: 'MyService'
+```
+
+You might want to use prefixes per environment:
+*staging/globals.yml*
+```
+variables:
+  newrelic.appname.prefix: 'Staging'
+```
+
+*staging/production.yml*
+```
+variables:
+  newrelic.appname.prefix: 'Prod'
+```
+
+*myservice.yml*
+```
+override:
+  env:
+    NEW_RELIC_APP_NAME: '%{newrelic.appname.prefix} MyService'
+```
+
 ### Variables
 Yaml files may contain an `variables:` section containing key/value pairs that will be substituted into the *json* template. All 
 variables in a templates must be resolved or it's considered an error. This can be used to ensure that some parameters are 

--- a/README.md
+++ b/README.md
@@ -177,14 +177,13 @@ hipchat:
     - '123456'
 ```
 
-### NewRelic
-If [NewRelic deployment notifications](https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/deployment-notifications) are desired you need to 
-both supply your [NewRelic REST API key](https://docs.newrelic.com/docs/apis/rest-api-v2/requirements/api-keys) (NOT the license key given to the agent) and set the `NEW_RELIC_APP_NAME` environment variable on the service:
+### New Relic
+To send [New Relic deployment notifications](https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/deployment-notifications) supply your [New Relic REST API key](https://docs.newrelic.com/docs/apis/rest-api-v2/requirements/api-keys) (different from the license key given to the agent) and set the `NEW_RELIC_APP_NAME` environment variable on the service. For example
 
 *globals.yml*
 ```
 newrelic:
-  token: 'i_am_an_api_token'
+  token: '123abc'
 ```
 
 *myservice.yml*
@@ -192,26 +191,6 @@ newrelic:
 override:
   env:
     NEW_RELIC_APP_NAME: 'MyService'
-```
-
-You might want to use prefixes per environment:
-*staging/globals.yml*
-```
-variables:
-  newrelic.appname.prefix: 'Staging'
-```
-
-*staging/production.yml*
-```
-variables:
-  newrelic.appname.prefix: 'Prod'
-```
-
-*myservice.yml*
-```
-override:
-  env:
-    NEW_RELIC_APP_NAME: '%{newrelic.appname.prefix} MyService'
 ```
 
 ### Variables

--- a/src/lighter/newrelic.py
+++ b/src/lighter/newrelic.py
@@ -1,0 +1,47 @@
+import logging
+import traceback
+import urllib2
+import lighter.util as util
+
+
+class NewRelic(object):
+    """
+    For ref see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/deployment-notifications
+    """
+
+    def __init__(self, api_key):
+        self._url = 'https://api.newrelic.com/deployments.xml'
+        self._api_key = api_key
+
+    def notify(self, app_name, version, description=None, changelog=None):
+        if self._api_key is None or self._api_key is '':
+            logging.debug('No HipChat api key configured for %s', app_name)
+            return
+
+        if app_name is None or app_name is '':
+            logging.debug('No NewRelic app name configured, app is most likely not on NewRelic')
+            return
+
+        logging.debug("Sending deployment notification to newrelic: %s %s %s %s", app_name, version, description,
+                      changelog)
+
+        try:
+            headers = {
+                'x-api-key': self._api_key
+            }
+
+            data = {
+                'deployment[app_name]': app_name,
+                'deployment[revision]': version,
+                'deployment[description]': description,
+                'deployment[changelog]': changelog,
+                'deployment[user]': 'Lighter'
+            }
+
+            return util.xmlRequest(self._url, method='POST', data=data, headers=headers, contentType='application/x-www-form-urlencoded')
+
+        except urllib2.URLError, e:
+            logging.warn(str(e))
+            print traceback.format_exc()
+            return {}
+

--- a/src/lighter/test.py
+++ b/src/lighter/test.py
@@ -3,6 +3,7 @@ from lighter.test.deploy_test import *
 from lighter.test.hipchat_test import *
 from lighter.test.maven_test import *
 from lighter.test.util_test import *
+from lighter.test.newrelic_test import *
 
 #logging.getLogger().setLevel(logging.DEBUG)
 

--- a/src/lighter/test/newrelic_test.py
+++ b/src/lighter/test/newrelic_test.py
@@ -1,0 +1,35 @@
+import unittest
+from mock import patch
+from lighter.newrelic import NewRelic
+
+
+class NewRelicTest(unittest.TestCase):
+    @patch('lighter.util.xmlRequest')
+    def testNotify(self, mock_xmlRequest):
+
+        newrelic = NewRelic('iamanapitoken')
+
+        newrelic.notify('FH Dev API SearchService', '1.2.3-test')
+        newrelic.notify('FH Dev API SearchService', '1.2.4-test', 'just testing')
+        newrelic.notify('FH Dev API SearchService', '1.2.5-test', 'just testing', 'changed something')
+
+        self.assertEquals(mock_xmlRequest.call_count, 3)
+
+    @patch('lighter.util.xmlRequest')
+    def testNoNewRelicApiKey(self, mock_xmlRequest):
+
+        newrelic = NewRelic('')
+
+        newrelic.notify('FH Dev API SearchService', '1.2.3-test')
+
+        self.assertEquals(mock_xmlRequest.call_count, 0)
+
+    @patch('lighter.util.xmlRequest')
+    def testAppNotInNewRelic(self, mock_xmlRequest):
+
+        newrelic = NewRelic('iamanapitoken')
+
+        newrelic.notify(None, '1.2.3-test')
+        newrelic.notify('', '1.2.4-test')
+
+        self.assertEquals(mock_xmlRequest.call_count, 0)

--- a/src/lighter/util.py
+++ b/src/lighter/util.py
@@ -1,4 +1,5 @@
 import os, urlparse, base64, json, urllib2, logging, itertools, types, re
+import urllib
 import xml.dom.minidom as minidom
 from copy import copy
 
@@ -54,7 +55,7 @@ def replace(template, variables):
                         raise KeyError('Variable %%{%s} not found' % varname)
                     result = result.replace('%{' + varname + '}', unicode(remainingvars[varname]))
                     del remainingvars[varname]
-                
+
     return result
 
 def find(collection, condition, default=None):
@@ -80,15 +81,19 @@ def urlunparse(data):
         url = url + '#' + fragment
     return url
 
-def buildRequest(url, data=None, headers={}, method='GET'):
+def buildRequest(url, data=None, headers={}, method='GET', contentType='application/json'):
     parsed_url = urlparse.urlparse(url)
     parts = list(parsed_url[0:6])
     parts[1] = ('@' in parts[1]) and parts[1].split('@')[1] or parts[1]
 
     body = None
     if data is not None:
-        body = json.dumps(data)
-        headers['Content-Type'] = 'application/json'
+        if contentType == 'application/json':
+            body = json.dumps(data)
+            headers['Content-Type'] = 'application/json'
+        elif contentType == 'application/x-www-form-urlencoded':
+            body = urllib.urlencode(data)
+            headers['Content-Type'] = 'application/x-www-form-urlencoded'
 
     request = urllib2.Request(urlunparse(parts), body, headers)
     request.get_method = lambda: method
@@ -101,19 +106,19 @@ def buildRequest(url, data=None, headers={}, method='GET'):
 
     return request
 
-def jsonRequest(url, data=None, headers={}, method='GET'):
+def jsonRequest(url, data=None, headers={}, method='GET', contentType='application/json'):
     logging.debug('%sing url %s', method, url)
-    response = urllib2.urlopen(buildRequest(url, data, headers, method))
+    response = urllib2.urlopen(buildRequest(url, data, headers, method, contentType))
     content = response.read()
     if response.info().gettype() == 'application/json' or response.info().gettype() == 'text/plain':
         return json.loads(content)
-    
+
     logging.debug('Content-Type %s is not json %s', response.info().gettype(), content)
     return {}
 
-def xmlRequest(url, data=None, headers={}, method='GET'):
+def xmlRequest(url, data=None, headers={}, method='GET', contentType='application/json'):
     logging.debug('%sing url %s', method, url)
-    response = urllib2.urlopen(buildRequest(url, data, headers, method)).read()
+    response = urllib2.urlopen(buildRequest(url, data, headers, method, contentType)).read()
     return xmlTransform(minidom.parseString(response).documentElement)
 
 def xmlText(nodelist):

--- a/src/resources/yaml/globals.yml
+++ b/src/resources/yaml/globals.yml
@@ -6,3 +6,5 @@ hipchat:
     - '123'
 variables:
   rabbitmq.url: amqp://localhost:5672
+newrelic:
+  token: 'i_am_an_api_token'

--- a/src/resources/yaml/staging/globals.yml
+++ b/src/resources/yaml/staging/globals.yml
@@ -2,6 +2,7 @@ facts:
   environment: "staging"
 variables:
   rabbitmq.url: "amqp://myserver:15672"
+  newrelic.appname.prefix: 'Staging'
 hipchat:
   rooms:
     - "456"

--- a/src/resources/yaml/staging/myservice.yml
+++ b/src/resources/yaml/staging/myservice.yml
@@ -9,6 +9,7 @@ override:
     SERVICE_BUILD: '%{lighter.uniqueVersion}'
     DATABASE: 'database:3306'
     CVAR: '%{cvar}'
+    NEW_RELIC_APP_NAME: '%{newrelic.appname.prefix} MyService'
   upgradeStrategy:
     maximumOverCapacity: 0.0
 hipchat:


### PR DESCRIPTION
If [NewRelic deployment notifications](https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/deployment-notifications) are desired you need to 
both supply your [NewRelic REST API key](https://docs.newrelic.com/docs/apis/rest-api-v2/requirements/api-keys) (NOT the license key given to the agent) and set the `NEW_RELIC_APP_NAME` environment variable on the service:

*globals.yml*
```
newrelic:
  token: 'i_am_an_api_token'
```

*myservice.yml*
```
override:
  env:
    NEW_RELIC_APP_NAME: 'MyService'
```

You might want to use prefixes per environment:
*staging/globals.yml*
```
variables:
  newrelic.appname.prefix: 'Staging'
```

*staging/production.yml*
```
variables:
  newrelic.appname.prefix: 'Prod'
```

*myservice.yml*
```
override:
  env:
    NEW_RELIC_APP_NAME: '%{newrelic.appname.prefix} MyService'
```