### PR TITLE
Send deployment notifications as events to Datadog

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,20 +197,12 @@ override:
 ```
 
 ### Datadog
-To send [Datadog deployment event](http://docs.datadoghq.com/guides/overview/#events) supply your [Datadog API key](https://app.datadoghq.com/account/settings#api). For example
+To send [Datadog deployment events](http://docs.datadoghq.com/guides/overview/#events) supply your [Datadog API key](https://app.datadoghq.com/account/settings#api). For example
 
 *globals.yml*
 ```
 datadog:
   token: '123abc'
-```
-
-*myservice.yml*
-```
-override:
-  env:
-    NEW_RELIC_LICENSE_KEY: 'abc123'
-    NEW_RELIC_APP_NAME: 'MyService'
 ```
 
 ### Variables

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ hipchat:
 ```
 
 ### New Relic
-To send [New Relic deployment notifications](https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/deployment-notifications) supply your [New Relic REST API key](https://docs.newrelic.com/docs/apis/rest-api-v2/requirements/api-keys) (different from the license key given to the agent) and set the `NEW_RELIC_APP_NAME` environment variable on the service. For example
+To send [New Relic deployment notifications](https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/deployment-notifications) supply your [New Relic REST API key](https://docs.newrelic.com/docs/apis/rest-api-v2/requirements/api-keys) (different from the license key given to the agent). For example
 
 *globals.yml*
 ```
@@ -192,6 +192,24 @@ newrelic:
 ```
 override:
   env:
+    NEW_RELIC_LICENSE_KEY: 'abc123'
+    NEW_RELIC_APP_NAME: 'MyService'
+```
+
+### Datadog
+To send [Datadog deployment event](http://docs.datadoghq.com/guides/overview/#events) supply your [Datadog API key](https://app.datadoghq.com/account/settings#api). For example
+
+*globals.yml*
+```
+datadog:
+  token: '123abc'
+```
+
+*myservice.yml*
+```
+override:
+  env:
+    NEW_RELIC_LICENSE_KEY: 'abc123'
     NEW_RELIC_APP_NAME: 'MyService'
 ```
 

--- a/src/lighter/datadog.py
+++ b/src/lighter/datadog.py
@@ -1,0 +1,46 @@
+import logging, urllib2
+import lighter.util as util
+
+class Datadog(object):
+    def __init__(self, api_key, url=None):
+        self._api_key = api_key
+        self._url = url or 'https://app.datadoghq.com'
+        self._message_attribs = {
+            'aggregation_key': 'Lighter Deployment',
+            'source_type_name': 'lighter'
+        }
+
+    def notify(self, title, message, tags=[], priority='normal', alert_type='info'):
+        if self._api_key is None or self._api_key is '':
+            logging.debug('No Datadog api key configured')
+            return
+        
+        if title is None or title is '':
+            logging.debug('Datadog title required')
+            return
+        
+        if message is None or message is '':
+            logging.debug('Datadog message required')
+            return
+
+        logging.debug("Sending Datadog event: %s", message)
+        self._call('/api/v1/events', util.merge(self._message_attribs, {
+            'title': title,
+            'message': message,
+            'tags':tags,
+            'priority': priority,
+            'alert_type': alert_type
+        }))
+
+    def _call(self, endpoint, data):
+        if self._url is None or self._api_key is None:
+            logging.debug('Datadog is not enabled')
+            return
+
+        try:
+            url = self._url.rstrip('/') + endpoint + '?api_key=' + self._api_key
+            logging.debug('Calling Datadog endpoint %s', endpoint)
+            util.jsonRequest(url, data=data, method='POST')
+        except urllib2.URLError, e:
+            logging.warn(str(e))
+            return {}

--- a/src/lighter/datadog.py
+++ b/src/lighter/datadog.py
@@ -2,27 +2,19 @@ import logging, urllib2
 import lighter.util as util
 
 class Datadog(object):
-    def __init__(self, api_key, url=None):
-        self._api_key = api_key
-        self._url = url or 'https://app.datadoghq.com'
+    def __init__(self, token):
+        self._token = token
+        self._url = 'https://app.datadoghq.com'
         self._message_attribs = {
             'aggregation_key': 'Lighter Deployment',
             'source_type_name': 'lighter'
         }
 
     def notify(self, title, message, tags=[], priority='normal', alert_type='info'):
-        if self._api_key is None or self._api_key is '':
-            logging.debug('No Datadog api key configured')
+        if not title or not message:
+            logging.warn('Datadog title and message required')
             return
         
-        if title is None or title is '':
-            logging.debug('Datadog title required')
-            return
-        
-        if message is None or message is '':
-            logging.debug('Datadog message required')
-            return
-
         logging.debug("Sending Datadog event: %s", message)
         self._call('/api/v1/events', util.merge(self._message_attribs, {
             'title': title,
@@ -33,12 +25,12 @@ class Datadog(object):
         }))
 
     def _call(self, endpoint, data):
-        if self._url is None or self._api_key is None:
+        if not self._url or not self._token:
             logging.debug('Datadog is not enabled')
             return
 
         try:
-            url = self._url.rstrip('/') + endpoint + '?api_key=' + self._api_key
+            url = self._url.rstrip('/') + endpoint + '?api_key=' + self._token
             logging.debug('Calling Datadog endpoint %s', endpoint)
             util.jsonRequest(url, data=data, method='POST')
         except urllib2.URLError, e:

--- a/src/lighter/hipchat.py
+++ b/src/lighter/hipchat.py
@@ -19,7 +19,7 @@ class HipChat(object):
             self._call('/v2/room/%s/notification' % room, util.merge({'message': message}, self._message_attribs))
 
     def _call(self, endpoint, data):
-        if self._url is None or self._token is None:
+        if not self._url or not self._token:
             logging.debug('HipChat is not enabled')
             return
 

--- a/src/lighter/main.py
+++ b/src/lighter/main.py
@@ -179,7 +179,7 @@ def deploy(marathonurl, filenames, noop=False, force=False):
             )
 
             # Send Datadog deployment notification
-            datadog = Datadog(util.rget(service.document,'datadog','api_key'))
+            datadog = Datadog(util.rget(service.document, 'datadog', 'token'))
             datadog.notify(
                 title="Deployed %s to %s" % (service.image, service.environment),
                 message="Lighter deployed **%s** with image **%s** to **%s** (%s)" % (service.id, service.image, service.environment, parsedMarathonUrl.netloc),

--- a/src/lighter/main.py
+++ b/src/lighter/main.py
@@ -6,6 +6,7 @@ from lighter.hipchat import HipChat
 import lighter.util as util
 import lighter.maven as maven
 from lighter.newrelic import NewRelic
+from lighter.datadog import Datadog
 
 
 def parsebool(value):
@@ -175,6 +176,14 @@ def deploy(marathonurl, filenames, noop=False, force=False):
             newrelic.notify(
                 util.rget(service.config, 'env', 'NEW_RELIC_APP_NAME'),
                 service.uniqueVersion
+            )
+
+            # Send Datadog deployment notification
+            datadog = Datadog(util.rget(service.document,'datadog','api_key'))
+            datadog.notify(
+                title="Deployed %s to %s" % (service.image, service.environment),
+                message="Lighter deployed **%s** with image **%s** to **%s** (%s)" % (service.id, service.image, service.environment, parsedMarathonUrl.netloc),
+                tags=[ "environment:%s" % service.environment ]
             )
 
         except urllib2.HTTPError, e:

--- a/src/lighter/newrelic.py
+++ b/src/lighter/newrelic.py
@@ -9,25 +9,25 @@ class NewRelic(object):
     For ref see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/deployment-notifications
     """
 
-    def __init__(self, api_key):
+    def __init__(self, token):
         self._url = 'https://api.newrelic.com/deployments.xml'
-        self._api_key = api_key
+        self._token = token
 
     def notify(self, app_name, version, description=None, changelog=None):
-        if self._api_key is None or self._api_key is '':
-            logging.debug('No HipChat api key configured for %s', app_name)
+        if not self._token:
+            logging.debug('No New Relic api key configured for %s', app_name)
             return
 
-        if app_name is None or app_name is '':
-            logging.debug('No NewRelic app name configured, app is most likely not on NewRelic')
+        if not app_name:
+            logging.debug('No New Relic app name configured, app is most likely not on NewRelic')
             return
 
-        logging.debug("Sending deployment notification to newrelic: %s %s %s %s", app_name, version, description,
+        logging.debug("Sending deployment notification to New Relic: %s %s %s %s", app_name, version, description,
                       changelog)
 
         try:
             headers = {
-                'x-api-key': self._api_key
+                'x-api-key': self._token
             }
 
             data = {

--- a/src/lighter/test.py
+++ b/src/lighter/test.py
@@ -4,6 +4,7 @@ from lighter.test.hipchat_test import *
 from lighter.test.maven_test import *
 from lighter.test.util_test import *
 from lighter.test.newrelic_test import *
+from lighter.test.datadog_test import *
 
 #logging.getLogger().setLevel(logging.DEBUG)
 

--- a/src/lighter/test/datadog_test.py
+++ b/src/lighter/test/datadog_test.py
@@ -1,0 +1,26 @@
+import unittest
+from mock import patch, ANY
+from lighter.datadog import Datadog
+import lighter.util
+
+class DatadogTest(unittest.TestCase):
+    @patch('lighter.util.jsonRequest')
+    def testNotify(self, mock_jsonRequest):
+        datadog = Datadog(api_key='abc').notify(title='test title', message='test message', tags=['environment:test'], priority='normal', alert_type='info')
+        mock_jsonRequest.assert_any_call('https://app.datadoghq.com/api/v1/events?api_key=abc', data=ANY, method='POST')
+        self.assertEquals(mock_jsonRequest.call_count, 1)
+    
+    @patch('lighter.util.jsonRequest')
+    def testNoApiKey(self, mock_jsonRequest):
+        datadog = Datadog('').notify(title='test title', message='test message', tags=['environment:test'], priority='normal', alert_type='info')
+        self.assertEquals(mock_jsonRequest.call_count, 0)
+        
+    @patch('lighter.util.jsonRequest')
+    def testNoTitle(self, mock_jsonRequest):
+        datadog = Datadog(api_key='abc').notify(title='', message='test message', tags=['environment:test'], priority='normal', alert_type='info')
+        self.assertEquals(mock_jsonRequest.call_count, 0)
+    
+    @patch('lighter.util.jsonRequest')
+    def testNoMessage(self, mock_jsonRequest):
+        datadog = Datadog(api_key='abc').notify(title='test title', message='', tags=['environment:test'], priority='normal', alert_type='info')
+        self.assertEquals(mock_jsonRequest.call_count, 0)

--- a/src/lighter/test/datadog_test.py
+++ b/src/lighter/test/datadog_test.py
@@ -6,9 +6,9 @@ import lighter.util
 class DatadogTest(unittest.TestCase):
     @patch('lighter.util.jsonRequest')
     def testNotify(self, mock_jsonRequest):
-        datadog = Datadog(api_key='abc').notify(title='test title', message='test message', tags=['environment:test'], priority='normal', alert_type='info')
-        mock_jsonRequest.assert_any_call('https://app.datadoghq.com/api/v1/events?api_key=abc', data=ANY, method='POST')
+        datadog = Datadog('abc').notify(title='test title', message='test message', tags=['environment:test'], priority='normal', alert_type='info')
         self.assertEquals(mock_jsonRequest.call_count, 1)
+        mock_jsonRequest.assert_any_call('https://app.datadoghq.com/api/v1/events?api_key=abc', data=ANY, method='POST')
     
     @patch('lighter.util.jsonRequest')
     def testNoApiKey(self, mock_jsonRequest):
@@ -17,10 +17,10 @@ class DatadogTest(unittest.TestCase):
         
     @patch('lighter.util.jsonRequest')
     def testNoTitle(self, mock_jsonRequest):
-        datadog = Datadog(api_key='abc').notify(title='', message='test message', tags=['environment:test'], priority='normal', alert_type='info')
+        datadog = Datadog('abc').notify(title='', message='test message', tags=['environment:test'], priority='normal', alert_type='info')
         self.assertEquals(mock_jsonRequest.call_count, 0)
     
     @patch('lighter.util.jsonRequest')
     def testNoMessage(self, mock_jsonRequest):
-        datadog = Datadog(api_key='abc').notify(title='test title', message='', tags=['environment:test'], priority='normal', alert_type='info')
+        datadog = Datadog('abc').notify(title='test title', message='', tags=['environment:test'], priority='normal', alert_type='info')
         self.assertEquals(mock_jsonRequest.call_count, 0)


### PR DESCRIPTION
Adds the ability to send deployment notifications as events to Datadog. You'll find your API key on [this page](https://app.datadoghq.com/account/settings#api).

To enable, simply add the following to your `globals.yaml`

    datadog:
        api_key: <your_key_here>