### PR TITLE
typos and comma fixes. paragraph line breaks changed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,13 @@
 # Lighter
 <a href='https://travis-ci.org/meltwater/lighter'><img src='https://secure.travis-ci.org/meltwater/lighter.png?branch=master'></a>
 
-[Lighter](https://en.wikipedia.org/wiki/Lighter_(barge)) solves the problem of automating 
-deployments to [Marathon](https://github.com/mesosphere/marathon) and handling of differences
-between multiple environments. Given a heirachy of yaml files and environments Ligther can 
-expand service config files and deploy them to Marathon. 
+[Lighter](https://en.wikipedia.org/wiki/Lighter_(barge)) solves the problem of automating deployments to [Marathon](https://github.com/mesosphere/marathon) and handling of differences between multiple environments. Given a hierachy of yaml files and environments, Lighter can expand service config files and deploy them to Marathon. 
 
-For even tighter integration into the development process Lighter can resolve Marathon config files 
-from Maven and merge these with environment specific overrides. This enables continuous deployment 
-whenever new releases or snapshots appear in the Maven repository. Optional version range constraints 
-allows for example patches/minor versions to be rolled out continuously, while requiring a config
-change to roll out major versions.
+For even tighter integration into the development process, Lighter can resolve Marathon config files from Maven and merge these with environment specific overrides. This enables continuous deployment whenever new releases or snapshots appear in the Maven repository. Optional version range constraints allows for example patches/minor versions to be rolled out continuously, while requiring a config change to roll out major versions.
 
 ## Environment Variables
 
- * **MARATHON_URL** - Marathon url, e.g. "http://marathon-host:8080/"
+ * **MARATHON_URL** - Marathon URL, e.g. "http://marathon-host:8080/"
 
 ## Usage
 
@@ -122,8 +115,7 @@ Expression | Resolve To
 [,]-SNAPSHOT | Latest *SNAPSHOT* version
 
 ##### Snapshot Builds
-If an image is rebuilt with the same Docker tag Marathon won't detect a change and roll out the new image. To ensure
-that new snapshot/latest versions are deployed use `%{lighter.uniqueVersion}` and `forcePullImage` like for example
+If an image is rebuilt with the same Docker tag, Marathon won't detect a change and hence won't roll out the new image. To ensure that new snapshot/latest versions are deployed use `%{lighter.uniqueVersion}` and `forcePullImage` like this:
 
 *myservice.yml*
 ```
@@ -136,10 +128,7 @@ override:
 ```
 
 ### Freestyle Services
-Yaml files may contain a `service:` tag which specifies a Marathon *json* fragment 
-to use as the service configuration base for further merging. This allows for
-services which aren't based on a *json* template but rather defined exclusively 
-in *yaml*.
+Yaml files may contain a `service:` tag which specifies a Marathon *json* fragment to use as the service configuration base for further merging. This allows for services which aren't based on a *json* template but rather defined exclusively in *yaml*.
 
 *myservice.yml*
 ```
@@ -156,8 +145,7 @@ service:
 ```
 
 ### Overrides
-Yaml files may contain an `override:` section that will be merged directly into the Marathon json. The 
-structure contained in the `override:` section must correspond to the [Marathon REST API](https://mesosphere.github.io/marathon/docs/rest-api.html#post-v2-apps). For example 
+Yaml files may contain an `override:` section that will be merged directly into the Marathon json. The structure contained in the `override:` section must correspond to the [Marathon REST API](https://mesosphere.github.io/marathon/docs/rest-api.html#post-v2-apps). For example 
 
 ```
 override:


### PR DESCRIPTION
## changes
- there were some strange line breaks. maybe a setting of your editor, or just a different style to do it? (I removed the linebreaks in larger paragraphs). please use --word-diff to see the wording changes I made within those paragraphs
- please double check if I understood correctly how the forcing of redeploys of snapshots work. I changed the wording there into the opposite, so I hope I got it right :)

## questions
- how to 'install' this? (I tried using install.sh and the comments in 'Deployment' section but did not succeed yet)
- do I have to set the MARATHON_URL in my environment? (I suspect that this is optional)
- if the installation fails, there is no feedback (e.g. when setting a wrong version string)
- what is the required python version?
- what do you mean by 'positional arguments'? I have not heard this before.
- is this supposed to be part of this repo? "src/resources/repository/com/meltwater/myservice-snapshot"
- what is the syntax for specifying the versions based on? (if that is an existing way to do it, maybe one could just point to the spec)
- If I was using lighter and a deployment as been done, how would I know that it has worked? Do I get a confirmation message, or a log files written, or similar?
- could hipchat, newrelic, and datadog be grouped in a section called 'integrations'? If yes, then they could potentially be moved to the end of the README?