### PR TITLE
Allow specifying environment variables as values in the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,26 @@ And used from the *json* template like
 }
 ```
 
+Lighter also allows specifying environment variables as values in the configuration yaml files.
+
+With the following configuration:
+*myservice.yml*
+```
+service:
+  id: '/myproduct/myservice'
+  container:
+    docker:
+      image: 'meltwater/myservice:%{env.VERSION}'
+  env:
+    DATABASE: 'database:3306'
+  cpus: 1.0
+  mem: 1200
+  instances: 1
+```
+
+And Running `VERSION=1.1.1 lighter deploy myservice.yml`, lighter will deploy the docker image ``meltwater/myservice:1.1.1`` to marathon.
+
+
 To avoid interpolating some string like ``%{id}`` when you really want it, use ``%%{id}``
 
 ### Predefined Variables

--- a/src/lighter/main.py
+++ b/src/lighter/main.py
@@ -254,7 +254,7 @@ if __name__ == '__main__':
         help='Deploy services to Marathon',
         description='Deploy services to Marathon')
     
-    deploy_parser.add_argument('-m', '--marathon', required=True, dest='marathon', help='Marathon URL like "http://marathon-host:8080/". Overrides default Marathon URL\'s provided in config files',
+    deploy_parser.add_argument('-m', '--marathon', dest='marathon', help='Marathon URL like "http://marathon-host:8080/". Overrides default Marathon URL\'s provided in config files',
                       default=os.environ.get('MARATHON_URL', ''))
     deploy_parser.add_argument('-f', '--force', dest='force', help='Force deployment even if the service is already affected by a running deployment [default: %(default)s]',
                       action='store_true', default=False)

--- a/src/lighter/main.py
+++ b/src/lighter/main.py
@@ -119,6 +119,9 @@ def parse_service(filename, targetdir=None, verifySecrets=False):
     # Merge overrides into json template
     config = util.merge(config, document.get('override', {}))
 
+    # Environment variables has the highest precedence
+    variables = util.EnvironmentVariables(variables)
+
     # Substitute variables into the config
     try:
         config = util.replace(config, variables)

--- a/src/lighter/test/util_test.py
+++ b/src/lighter/test/util_test.py
@@ -1,4 +1,4 @@
-import unittest
+import os, unittest
 import lighter.main as lighter
 import lighter.util as util
 
@@ -33,7 +33,7 @@ class UtilTest(unittest.TestCase):
         x = {'a':'%{env.ES_PORT}'}
         m = {'a':'9300'}
         os.environ['ES_PORT'] = '9300'
-        self.assertEquals(util.replace(x, util.FixedVariables({})), m)
+        self.assertEquals(util.replace(x, util.EnvironmentVariables(util.FixedVariables({}))), m)
 
     def testCompare(self):
         x = {'a': 1, 'b': 2}

--- a/src/lighter/test/util_test.py
+++ b/src/lighter/test/util_test.py
@@ -29,6 +29,12 @@ class UtilTest(unittest.TestCase):
         m = {'a':'abc%{var}def', 'b':'abc1def'}
         self.assertEquals(util.replace(x, util.FixedVariables({'var':'1'})), m)
 
+    def testReplaceEnv(self):
+        x = {'a':'%{env.ES_PORT}'}
+        m = {'a':'9300'}
+        os.environ['ES_PORT'] = '9300'
+        self.assertEquals(util.replace(x, util.FixedVariables({})), m)
+
     def testCompare(self):
         x = {'a': 1, 'b': 2}
         y = {'b': 3, 'c': 4}

--- a/src/lighter/util.py
+++ b/src/lighter/util.py
@@ -111,14 +111,13 @@ def replace(template, variables):
                 if not names:
                     break
                 for name in names:
-                    value = unicode(remaining.pop(name))
+                    value = name.startswith('env.') ? os.environ[name[4:]] : unicode(remaining.pop(name))
                     result = result.replace('%{' + name + '}', value)
             while True:
                 names = re.findall(r"%%\{([\w\.]+)\}", result)
                 if not names:
                     break
                 for name in names:
-                    value = unicode(remaining.pop(name))
                     result = result.replace('%%{' + name + '}', '%{' + name + '}')
 
     return result


### PR DESCRIPTION
- Allow specifying environment variables as values in the configuration
- Broke env var replacement into separate class
- Fix the parsing of the marathon url argument not being optional