### PR TITLE
Fix build errors in the mac osx environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 \#*
 build/
 dist/
+target/
 lighter*.spec
 travis.log
 .coverage

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e -x
 . ./common.sh
 

--- a/common.sh
+++ b/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Copied from https://github.com/pyca/cryptography/blob/master/.travis/run.sh
 set -e -x
 

--- a/common.sh
+++ b/common.sh
@@ -4,7 +4,7 @@ set -e -x
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
     # initialize our pyenv
-    PYENV_ROOT="$HOME/.pyenv"
+    PYENV_ROOT=${PYENV_ROOT:-"$HOME/.pyenv"}
     PATH="$PYENV_ROOT/bin:$PATH"
     eval "$(pyenv init -)"
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Copied from https://github.com/pyca/cryptography/blob/master/.travis/install.sh
 set -e -x
 

--- a/install.sh
+++ b/install.sh
@@ -10,11 +10,12 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     fi
 
     brew outdated libffi || brew upgrade libffi
-    [[ -f "/usr/local/opt/libffi/lib/libffi.6.dylib" ]] || brew unlink pkg-config && brew install pkg-config libffi
+    brew outdated pkg-config || brew upgrade pkg-config
+    [[ -f "/usr/local/opt/libffi/lib/libffi.6.dylib" ]] || brew install libffi
 
     # install pyenv
-    git clone https://github.com/yyuu/pyenv.git ~/.pyenv
-    PYENV_ROOT="$HOME/.pyenv"
+    [[ -d ~/.pyenv ]] || git clone https://github.com/yyuu/pyenv.git ~/.pyenv
+    PYENV_ROOT=${PYENV_ROOT:-"$HOME/.pyenv"}
     PATH="$PYENV_ROOT/bin:$PATH"
     eval "$(pyenv init -)"
 
@@ -29,4 +30,4 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     source ~/.venv/bin/activate
 fi
 
-pip install -r requirements.txt
+pip install --upgrade -r requirements.txt

--- a/lighter
+++ b/lighter
@@ -1,8 +1,9 @@
 #!/bin/sh
-set -e
+set -e -x
+. "`dirname $0`/common.sh"
 
 export PYTHONPATH=".:`dirname $0`/src"
-python "`dirname $0`/src/lighter/main.py" $@
+python "`dirname $0`/src/lighter/main.py" -t "`dirname $0`/target" $@
 
 # Make sure the output files are writable outside the Docker container
 if [ -e "/tmp/lighter" ]; then

--- a/test
+++ b/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e -x
 . ./common.sh
 


### PR DESCRIPTION
This PR includes :


- Don't overwrite PYENV_ROOT env if it's already available
- Fix exceptions when running the lighter main python script to deploy
- use /bin/sh to be compatible with environments without the bash shell


Thanks