### PR TITLE
Avoid dependency on what specific encryption algorithm Secretary uses

### DIFF
--- a/src/lighter/secretary.py
+++ b/src/lighter/secretary.py
@@ -8,7 +8,7 @@ import lighter.util as util
 
 # Regexp to parse simple PEM files
 _PEM_RE = re.compile(u"-----BEGIN (.+?)-----\r?\n(.+?)\r?\n-----END \\1-----")
-_ENVELOPES_RE = re.compile(u"ENC\[NACL,[a-zA-Z0-9+/=\s]+\]")
+_ENVELOPES_RE = re.compile(u"ENC\[\w+,[a-zA-Z0-9+/=\s]+\]")
 
 class KeyEncoder(object):
     """

--- a/src/lighter/test/secretary_test.py
+++ b/src/lighter/test/secretary_test.py
@@ -43,6 +43,10 @@ class SecretaryTest(unittest.TestCase):
         self.assertEqual(2, len(envelopes))
         self.assertEqual(["ENC[NACL,uSr123+/=]", "ENC[NACL,pWd123+/=]"], envelopes)
 
+        envelopes = secretary.extractEnvelopes("amqp://ENC[NACL,uSr123+/=]:ENC[NACL,pWd123+/=]@rabbit:5672/ENC[KMS,123abc+/=]")
+        self.assertEqual(3, len(envelopes))
+        self.assertEqual(["ENC[NACL,uSr123+/=]", "ENC[NACL,pWd123+/=]", "ENC[KMS,123abc+/=]"], envelopes)
+
         envelopes = secretary.extractEnvelopes("amqp://ENC[NACL,]:ENC[NACL,pWd123+/=]@rabbit:5672/")
         self.assertEqual(1, len(envelopes))
         self.assertEqual(["ENC[NACL,pWd123+/=]"], envelopes)


### PR DESCRIPTION
Removes the explicit dependency on what encryption algorithms Secretary supports and uses (e.g. NaCL or KMS at the moment)