### PR TITLE
Support overriding specific list indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,48 @@ override:
     NEW_RELIC_LICENSE_KEY: '123abc'
 ```
 
+### Deep Merge
+An YAML and JSON file upwards-recursive deep merge is performed when parsing service definitions. Precedence is defined by the directory structure
+
+* myservice.yml has the highest precedence
+* globals.yml files are merged with decreasing precedency upwards in the directory structure
+* myservice-1.0.0-marathon.json if fetched from Maven has the lowest precedence
+
+Lists, dicts and scalar values are deep merged 
+
+ * Dicts are deep merged, the result containing the union of all keys
+ * Lists are appended together
+ * Scalar values coalesce to the not-null value with highest precedence
+
+The default behaviour is to append lists together, however specific list items can be overriden and deep merged using a dict with integer keys. For example
+
+*myservice-1.0.0-marathon.json*
+```
+{
+    "container": {
+        "docker": {
+            "portMappings": [
+                {"containerPort": 8080, "servicePort": 1234},
+                {"containerPort": 8081, "servicePort": 1235}
+            ]
+        }
+    }
+}
+```
+
+*myservice-override-serviceport.yml*
+```
+override:
+  container:
+    docker:
+      portMappings:
+        # Override service ports 1234,1235 with port 4000,4001
+        0: 
+          servicePort: 4000
+        1: 
+          servicePort: 4001
+```
+
 ## Variables
 Yaml files may contain an `variables:` section containing key/value pairs that will be substituted into the *json* template. All
 variables in a templates must be resolved or it's considered an error. This can be used to ensure that some parameters are

--- a/src/lighter/test/deploy_test.py
+++ b/src/lighter/test/deploy_test.py
@@ -61,6 +61,15 @@ class DeployTest(unittest.TestCase):
         self.assertEquals(service.config['env']['SERVICE_VERSION'], '1.1.1-SNAPSHOT')
         self.assertEquals(service.config['env']['SERVICE_BUILD'], '1.1.1-20151102.035053-8-marathon')
 
+    def testParseListOverride(self):
+        # servicePort=1234 in json, no override in yaml
+        service = lighter.parse_service('src/resources/yaml/staging/myservice-serviceport-nooverride.yml')
+        self.assertEquals(service.config['container']['docker']['portMappings'][0]['servicePort'], 1234)
+
+        # servicePort=1234 in json, override with servicePort=4000 in yaml
+        service = lighter.parse_service('src/resources/yaml/staging/myservice-serviceport-override.yml')
+        self.assertEquals(service.config['container']['docker']['portMappings'][0]['servicePort'], 4000)
+
     def _parseErrorPost(self, url, *args, **kwargs):
         if url.startswith('file:'):
             return jsonRequest(url, *args, **kwargs)

--- a/src/lighter/test/util_test.py
+++ b/src/lighter/test/util_test.py
@@ -10,25 +10,38 @@ class UtilTest(unittest.TestCase):
         z = {'c': 5, 'd': 6}
 
         m = {'a': 1, 'b': 3, 'c': 5, 'd': 6}
-        self.assertEqual(util.merge(x, y, z), m)
+        self.assertEqual(m, util.merge(x, y, z))
+
         m = {'a': 1, 'b': 2, 'c': 4, 'd': 6}
-        self.assertEqual(util.merge(z, y, x), m)
+        self.assertEqual(m, util.merge(z, y, x))
 
     def testMergeLists(self):
         x = {'a': [1, 2]}
         y = {'a': [2, 3]}
         m = {'a': [1, 2, 2, 3]}
-        self.assertEquals(util.merge(x, y), m)
+        self.assertEquals(m, util.merge(x, y))
+
+    def testMergeListOverride(self):
+        x = {'a': [1, 2]}
+        y = {'a': {1: 3}}
+        m = {'a': [1, 3]}
+        self.assertEquals(m, util.merge(x, y))
+
+    def testMergeListOverrideDeep(self):
+        x = {'a': [1, {'a': 2, 'b': 3}]}
+        y = {'a': {1: {'a': 4}}}
+        m = {'a': [1, {'a': 4, 'b': 3}]}
+        self.assertEquals(m, util.merge(x, y))
 
     def testReplace(self):
         x = {'a': 'abc%{var}def %{var}', 'b': ['%{var} %{ var2 } %{var3}'], 'c': {'d': '%{var2} %{var3}'}}
         m = {'a': 'abc1def 1', 'b': ['1 2 3'], 'c': {'d': '2 3'}}
-        self.assertEquals(util.replace(x, util.FixedVariables({'var': '1', 'var2': 2, 'var3': '3'})), m)
+        self.assertEquals(m, util.replace(x, util.FixedVariables({'var': '1', 'var2': 2, 'var3': '3'})))
 
     def testReplaceEscape(self):
         x = {'a': 'abc%%{var}def %%{var}def', 'b': 'abc%{var}def %{var}'}
         m = {'a': 'abc%{var}def %{var}def', 'b': 'abc1def 1'}
-        self.assertEquals(util.replace(x, util.FixedVariables({'var': '1'})), m)
+        self.assertEquals(m, util.replace(x, util.FixedVariables({'var': '1'})))
 
     def testReplaceEnv(self):
         x = {'a': '%{env.ES_PORT}'}

--- a/src/lighter/util.py
+++ b/src/lighter/util.py
@@ -26,22 +26,30 @@ def toList(a):
 
 def merge(*args):
     args = list(args)
-    result = copy(args.pop(0))
+    aval = copy(args.pop(0))
 
     while args:
-        b = args.pop(0)
+        bval = args.pop(0)
 
-        for key in set(result.keys() + b.keys()):
-            aval = result.get(key)
-            bval = b.get(key)
-            if isinstance(aval, dict) or isinstance(bval, dict):
-                result[key] = merge(aval or {}, bval or {})
-            elif isinstance(aval, (list, tuple)) or isinstance(bval, (list, tuple)):
-                result[key] = toList(aval) + toList(bval)
-            else:
-                result[key] = bval if (bval is not None) else aval
+        if isinstance(aval, (list, tuple)) and isinstance(bval, (dict)):
+            # Override and deep merge specific list items
+            aval = toList(aval)
+            for key, value in bval.items():
+                aval[int(key)] = merge(aval[int(key)], value)
+        elif isinstance(aval, dict) and isinstance(bval, dict):
+            # Deep merge dicts
+            for key in set(aval.keys() + bval.keys()):
+                asubval = aval.get(key)
+                bsubval = bval.get(key)
+                aval[key] = merge(asubval, bsubval)
+        elif isinstance(aval, (list, tuple)) and isinstance(bval, (list, tuple)):
+            # Append lists
+            aval = toList(aval) + toList(bval)
+        elif bval is not None:
+            # Scalar values
+            aval = bval
 
-    return result
+    return aval
 
 class FixedVariables(object):
     def __init__(self, variables):

--- a/src/resources/yaml/staging/myservice-serviceport-nooverride.yml
+++ b/src/resources/yaml/staging/myservice-serviceport-nooverride.yml
@@ -1,0 +1,4 @@
+maven:
+  groupid: 'com.meltwater'
+  artifactid: 'myservice'
+  version: '1.1.1-SNAPSHOT'

--- a/src/resources/yaml/staging/myservice-serviceport-override.yml
+++ b/src/resources/yaml/staging/myservice-serviceport-override.yml
@@ -1,0 +1,10 @@
+maven:
+  groupid: 'com.meltwater'
+  artifactid: 'myservice'
+  version: '1.1.1-SNAPSHOT'
+override:
+  container:
+    docker:
+      portMappings:
+        0: 
+          servicePort: 4000


### PR DESCRIPTION
Allows overriding for example a specific servicePort so the same service can be deployed in multiple configurations. See diff of README.md for detailed explanation of use case