### PR TITLE
Check that envvars are valid identifiers when using encrypted strings

### DIFF
--- a/src/lighter/test/secretary_test.py
+++ b/src/lighter/test/secretary_test.py
@@ -62,3 +62,13 @@ class SecretaryTest(unittest.TestCase):
         envelopes = secretary.extractEnvelopes("amqp://ENC[NACL,abc:ENC[NACL,pWd123+/=]@rabbit:5672/")
         self.assertEqual(1, len(envelopes))
         self.assertEqual(["ENC[NACL,pWd123+/=]"], envelopes)
+
+    def testServiceWithEnvvarDots(self):
+        try:
+            lighter.parse_service('src/resources/yaml/staging/myservice-encrypted-dots.yml')
+        except RuntimeError, e:
+            self.assertEquals(
+                "The env var 'database.uri' is not a valid shell script identifier and not supported by Secretary. " +
+                "Only alphanumeric characters and underscores are supported, starting with an alphabetic or underscore character.", e.message)
+        else:
+            self.fail("Expected exception RuntimeError")

--- a/src/resources/yaml/staging/myservice-encrypted-dots.yml
+++ b/src/resources/yaml/staging/myservice-encrypted-dots.yml
@@ -1,0 +1,7 @@
+maven:
+  groupid: 'com.meltwater'
+  artifactid: 'myservice'
+  version: '1.1.1-SNAPSHOT'
+override:
+  env:
+    database.uri: 'jdbc:mysql:root:ENC[NACL,01cKxvWaxe1BDZCTDgjX548fTUS5mtlBxdVR0dvrHNJDFJMK50N6d7/kkxi6lA==]//my-server:3306/comscore'

--- a/src/resources/yaml/staging/myservice-encrypted-substrings.yml
+++ b/src/resources/yaml/staging/myservice-encrypted-substrings.yml
@@ -9,6 +9,7 @@ override:
     SERVICE_BUILD: '%{lighter.uniqueVersion}'
     DATABASE_PASSWORD: 'ENC[NACL,deadbeef]'
     CVAR: '%{cvar}'
+    variable.with.dots: 'foo'
     NEW_RELIC_APP_NAME: '%{newrelic.appname.prefix} MyService'
     SSH_PRIVATE_KEY: |
       ENC[NACL,egFSuFDkZxsmv9w7bWyZyxCBQQeykctG2H6UTiK7EHRdQI3E3NsZBP8 


### PR DESCRIPTION
When Secretary decrypts something it outputs a scriptlet that is sourced into the env, to overwrite encrypted env vars with decrypted ones. Meaning that env vars with encrypted substrings like rabbitmq.password won't work since they contain dots. This change ensure the problem is caught at configuration time rather than at runtime,