### PR TITLE
Coerce envvar to strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,34 @@ override:
           servicePort: 4001
 ```
 
+#### Non-string Environment Variables
+Booleans, integers and floats in the `env` section are converted to strings before being posted
+to Marathon. Non-scalar environment variables like dicts and lists are deep merged and automatically
+serialized to json strings.
+
+*myservice.yml*
+```
+override:
+  env:
+    intvar: 123
+    boolvar: TRUE
+    dictvar:
+      mykey:
+       - 1
+       - 'abc'
+```
+
+Would result in a rendered json like
+```
+{
+  "env": {
+    "intvar": "123",
+    "boolvar": "true",
+    "dictvar": "{\"mykey\": [1, \"abc\"]}"
+  }
+}
+```
+
 ## Variables
 Yaml files may contain an `variables:` section containing key/value pairs that will be substituted into the *json* template. All
 variables in a templates must be resolved or it's considered an error. This can be used to ensure that some parameters are

--- a/src/lighter/test/deploy_test.py
+++ b/src/lighter/test/deploy_test.py
@@ -133,6 +133,23 @@ class DeployTest(unittest.TestCase):
         except RuntimeError as e:
             self.assertEquals(e.message, 'Failed to parse %s with the following message: Variable %%{bvar} not found' % service_yaml)
         else:
+            self.fail('Expected RuntimeError')
+
+    def testNonStringEnvvar(self):
+        service = lighter.parse_service('src/resources/yaml/integration/myservice-nonstring-envvar.yml')
+        self.assertEquals('123', service.config['env']['INTVAR'])
+        self.assertEquals('123.456', service.config['env']['FLOATVAR'])
+        self.assertEquals('true', service.config['env']['TRUEVAR'])
+        self.assertEquals('false', service.config['env']['FALSEVAR'])
+        self.assertEquals('{"foobar": [1, 2], "foo": "bar", "bar": 123}', service.config['env']['COMPLEXVAR'])
+
+    def testNonStringEnvkey(self):
+        service_yaml = 'src/resources/yaml/integration/myservice-nonstring-envkey.yml'
+        try:
+            lighter.parse_service(service_yaml)
+        except ValueError as e:
+            self.assertEquals(e.message, 'Only string dict keys are supported, please use quotes around the key \'True\' in %s' % service_yaml)
+        else:
             self.fail('Expected ValueError')
 
     def testParseNoMavenService(self):

--- a/src/resources/yaml/integration/myservice-nonstring-envkey.yml
+++ b/src/resources/yaml/integration/myservice-nonstring-envkey.yml
@@ -1,0 +1,11 @@
+maven:
+  groupid: 'com.meltwater'
+  artifactid: 'myservice'
+  resolve: '[1.0.0,1.1.0)'
+override:
+  env:
+    TRUE: '123'
+variables:
+  avar: '123'
+  bvar: '%{avar}'
+  cvar: '%{avar}'

--- a/src/resources/yaml/integration/myservice-nonstring-envvar.yml
+++ b/src/resources/yaml/integration/myservice-nonstring-envvar.yml
@@ -1,0 +1,18 @@
+maven:
+  groupid: 'com.meltwater'
+  artifactid: 'myservice'
+  resolve: '[1.0.0,1.1.0)'
+override:
+  env:
+    INTVAR: 123
+    TRUEVAR: true
+    FALSEVAR: false
+    FLOATVAR: 123.456
+    COMPLEXVAR:
+      foo: 'bar'
+      bar: 123
+      foobar: [1,2]
+variables:
+  avar: '123'
+  bvar: '%{avar}'
+  cvar: '%{avar}'


### PR DESCRIPTION
Solves #33

* Coerce non-string envvars to strings
* Validate that env var keys are strings
* Bonus also implements deep-merge and json serialize for non-scalars. Useful for apps that accept json formatted envvars