### PR TITLE
Allow version ranges in the 'version' tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Versions can be dynamically resolved from Maven using a range syntax.
 maven:
   groupid: 'com.example'
   artifactid: 'myservice'
-  resolve: '[1.0.0,2.0.0)'
+  version: '[1.0.0,2.0.0)'
 ```
 
 For example

--- a/src/lighter/main.py
+++ b/src/lighter/main.py
@@ -132,7 +132,7 @@ def parse_service(filename, targetdir=None, verifySecrets=False):
         coord = document['maven']
 
         resolver = maven.ArtifactResolver(coord['repository'], coord['groupid'], coord['artifactid'], coord.get('classifier'))
-        version = coord.get('version') or resolver.resolve(coord['resolve'])
+        version = resolver.resolve(coord.get('version') or coord['resolve'])
 
         artifact = resolver.fetch(version)
         config = util.merge(config, artifact.body)

--- a/src/lighter/maven.py
+++ b/src/lighter/maven.py
@@ -8,7 +8,7 @@ class VersionRange(object):
     SPLIT = re.compile('[^\d\w_]+')
 
     def __init__(self, expression):
-        result = re.match('([\(\[])\s*((?:\d+\.)*\d+)?\s*,\s*((?:\d+\.)*\d+)?\s*([\)\]])', expression)
+        result = VersionRange.parseExpression(expression)
         if not result:
             raise ValueError('%s is not a valid version range' % expression)
 
@@ -16,6 +16,14 @@ class VersionRange(object):
         self._lversion = VersionRange.parseVersion(lversion)
         self._rversion = VersionRange.parseVersion(rversion)
         self._suffix = VersionRange.suffix(expression)
+
+    @staticmethod
+    def parseExpression(expression):
+        return re.match('([\(\[])\s*((?:\d+\.)*\d+)?\s*,\s*((?:\d+\.)*\d+)?\s*([\)\]])', expression)
+
+    @staticmethod
+    def isExpression(expression):
+        return bool(VersionRange.parseExpression(expression))
 
     def accepts(self, version):
         parsed = self.parseVersion(version)
@@ -127,9 +135,16 @@ class ArtifactResolver(object):
             raise RuntimeError("Failed to retrieve %s (%s)" % (url, e)), None, sys.exc_info()[2]
 
     def resolve(self, expression):
+        # If it's not a valid version range expression, assume it's a specific version
+        if not VersionRange.isExpression(expression):
+            return expression
+
+        # Fetch the available versions for this artifact
         metadata = util.xmlRequest('{0}/{1}/{2}/maven-metadata.xml'.format(self._url, self._groupid.replace('.', '/'), self._artifactid))
         versions = util.toList(util.rget(metadata, 'versioning', 'versions', 'version'))
         logging.debug('%s:%s candidate versions %s', self._groupid, self._artifactid, versions)
+
+        # Select the version that best matches the version range expression
         return self.selectVersion(expression, versions)
 
     def selectVersion(self, expression, versions):

--- a/src/lighter/test/deploy_test.py
+++ b/src/lighter/test/deploy_test.py
@@ -101,6 +101,14 @@ class DeployTest(unittest.TestCase):
             lighter.deploy('http://localhost:1/', filenames=['src/resources/yaml/integration/myservice.yml'])
             self.assertTrue(self._called)
 
+    def testRangeInVersionTag(self):
+        """
+        Checks that version ranges can be resolved in the "version: " tag as well
+        """
+        with patch('lighter.util.jsonRequest', wraps=self._createJsonRequestWrapper()):
+            lighter.deploy('http://localhost:1/', filenames=['src/resources/yaml/integration/myservice-version-range.yml'])
+            self.assertTrue(self._called)
+
     def testMarathonAppNot404(self):
         with patch('lighter.util.jsonRequest', wraps=self._createJsonRequestWrapper('http://defaultmarathon:2')) as m_urlopen:
             resp = Mock()

--- a/src/lighter/test/maven_test.py
+++ b/src/lighter/test/maven_test.py
@@ -6,6 +6,10 @@ class MavenTest(unittest.TestCase):
         resolver = maven.ArtifactResolver('file:./src/resources/repository/', 'com.meltwater', 'myservice')
         self.assertEquals(resolver.resolve('[1.0.0,2.0.0)'), '1.1.0')
 
+    def testResolveSpecificVersion(self):
+        resolver = maven.ArtifactResolver('file:./src/resources/repository/', 'com.meltwater', 'myservice')
+        self.assertEquals(resolver.resolve('1.2.0'), '1.2.0')
+
     def testSelectVersionInclusive(self):
         resolver = maven.ArtifactResolver('file:./src/resources/repository/', 'com.meltwater', 'myservice')
         def select(expression, versions):

--- a/src/resources/yaml/integration/myservice-version-range.yml
+++ b/src/resources/yaml/integration/myservice-version-range.yml
@@ -1,0 +1,12 @@
+maven:
+  groupid: 'com.meltwater'
+  artifactid: 'myservice'
+  version: '[1.0.0,1.1.0)'
+override:
+  cpus: 1.0
+  env:
+    DATABASE: 'database:3306'
+variables:
+  avar: '123'
+  bvar: '%{avar}'
+  cvar: '%{avar}'


### PR DESCRIPTION
Based on popular demand

* Having separate tags for `version` and `resolve` proved non-intuitive. Several errors because users switched between specific versions and version ranges, without switching the version/resolve tag
* This deprecates but doesn't remove the `resolve` tag

Ping @antonha