### PR TITLE
 Improved error message when a list index override doesn't exist 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: test build
+all: test build verify
 
 build:
 	./build.sh
@@ -6,10 +6,13 @@ build:
 test:
 	./test
 
+verify:
+	./dist/lighter-$$(uname -s)-$$(uname -m) verify src/resources/yaml/staging/myservice.yml
+
 clean:
 	rm -rf ./build ./dist
 
 format:
 	./format
 
-.PHONY: build test clean format
+.PHONY: build test verify clean format

--- a/src/lighter/test/util_test.py
+++ b/src/lighter/test/util_test.py
@@ -10,10 +10,10 @@ class UtilTest(unittest.TestCase):
         z = {'c': 5, 'd': 6}
 
         m = {'a': 1, 'b': 3, 'c': 5, 'd': 6}
-        self.assertEqual(m, util.merge(x, y, z))
+        self.assertEqual(m, util.merge(util.merge(x, y), z))
 
         m = {'a': 1, 'b': 2, 'c': 4, 'd': 6}
-        self.assertEqual(m, util.merge(z, y, x))
+        self.assertEqual(m, util.merge(util.merge(z, y), x))
 
     def testMergeLists(self):
         x = {'a': [1, 2]}
@@ -26,6 +26,15 @@ class UtilTest(unittest.TestCase):
         y = {'a': {1: 3}}
         m = {'a': [1, 3]}
         self.assertEquals(m, util.merge(x, y))
+
+    def testMergeListNonexisting(self):
+        x = {'a': {'b': [1, 2]}}
+        y = {'a': {'b': {1: 3, 4: 4}}}
+        try:
+            util.merge(x, y)
+            self.fail("Expected exception ValueError")
+        except IndexError, e:
+            self.assertEquals("The given list override index a.b[4] doesn't exist", e.message)
 
     def testMergeListOverrideDeep(self):
         x = {'a': [1, {'a': 2, 'b': 3}]}

--- a/src/lighter/util.py
+++ b/src/lighter/util.py
@@ -24,30 +24,28 @@ def toList(a):
         return a
     return [a] if (a is not None) else []
 
-def merge(*args):
-    args = list(args)
-    aval = copy(args.pop(0))
+def merge(aval, bval, path=''):
+    aval = copy(aval)
 
-    while args:
-        bval = args.pop(0)
-
-        if isinstance(aval, (list, tuple)) and isinstance(bval, (dict)):
-            # Override and deep merge specific list items
-            aval = toList(aval)
-            for key, value in bval.items():
-                aval[int(key)] = merge(aval[int(key)], value)
-        elif isinstance(aval, dict) and isinstance(bval, dict):
-            # Deep merge dicts
-            for key in set(aval.keys() + bval.keys()):
-                asubval = aval.get(key)
-                bsubval = bval.get(key)
-                aval[key] = merge(asubval, bsubval)
-        elif isinstance(aval, (list, tuple)) and isinstance(bval, (list, tuple)):
-            # Append lists
-            aval = toList(aval) + toList(bval)
-        elif bval is not None:
-            # Scalar values
-            aval = bval
+    if isinstance(aval, (list, tuple)) and isinstance(bval, (dict)):
+        # Override and deep merge specific list items
+        aval = toList(aval)
+        for key, value in bval.items():
+            if int(key) < 0 or int(key) >= len(aval):
+                raise IndexError("The given list override index %s[%d] doesn't exist" % (path.lstrip('.'), int(key)))
+            aval[int(key)] = merge(aval[int(key)], value, '%s[%d]' % (path, int(key)))
+    elif isinstance(aval, dict) and isinstance(bval, dict):
+        # Deep merge dicts
+        for key in set(aval.keys() + bval.keys()):
+            asubval = aval.get(key)
+            bsubval = bval.get(key)
+            aval[key] = merge(asubval, bsubval, '%s.%s' % (path, key))
+    elif isinstance(aval, (list, tuple)) and isinstance(bval, (list, tuple)):
+        # Append lists
+        aval = toList(aval) + toList(bval)
+    elif bval is not None:
+        # Scalar values
+        aval = bval
 
     return aval
 


### PR DESCRIPTION
The previous error message was just a cryptical "index out of range" with no hint on where in the yaml files it was encountered. This improves the error message and shows the path of the problem like "docker.container.portMappings[1]"