### PR TITLE
Improved Datadog event tagging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,8 @@ To send [Datadog deployment events](http://docs.datadoghq.com/guides/overview/#e
 ```
 datadog:
   token: '123abc'
+  tags:
+    - subsystem:example
 ```
 
 For deployments of Docker containers, Lighter will add Marathon appid as a Docker container label in order for Datadog to tag services, [see: collect_labels_as_tags](https://github.com/DataDog/dd-agent/blob/master/conf.d/docker_daemon.yaml.example)

--- a/src/lighter/datadog.py
+++ b/src/lighter/datadog.py
@@ -3,9 +3,10 @@ import urllib2
 import lighter.util as util
 
 class Datadog(object):
-    def __init__(self, token):
+    def __init__(self, token, tags=[]):
         self._token = token
         self._url = 'https://app.datadoghq.com'
+        self._tags = tags + ['source:lighter']
 
     def notify(self, title, message, id, tags=[], priority='normal', alert_type='info'):
         if not title or not message or not id:
@@ -17,7 +18,7 @@ class Datadog(object):
             'title': title,
             'text': message,
             'aggregation_key': 'lighter_' + id,
-            'tags': tags,
+            'tags': list(tags) + self._tags,
             'priority': priority,
             'alert_type': alert_type
         })

--- a/src/lighter/main.py
+++ b/src/lighter/main.py
@@ -244,7 +244,9 @@ def deploy(marathonurl, filenames, noop=False, force=False, targetdir=None):
             )
 
             # Send Datadog deployment notification
-            datadog = Datadog(util.rget(service.document, 'datadog', 'token'))
+            datadog = Datadog(
+                util.rget(service.document, 'datadog', 'token'),
+                util.toList(util.rget(service.document, 'datadog', 'tags')))
             datadog.notify(
                 id=service.id,
                 title="Deployed %s to the %s environment" % (service.id, service.environment),

--- a/src/lighter/test/datadog_test.py
+++ b/src/lighter/test/datadog_test.py
@@ -1,6 +1,8 @@
 import unittest
 from mock import patch, ANY
 from lighter.datadog import Datadog
+import lighter.main as lighter
+from lighter.util import jsonRequest
 
 class DatadogTest(unittest.TestCase):
     @patch('lighter.util.jsonRequest')
@@ -40,3 +42,41 @@ class DatadogTest(unittest.TestCase):
     def testNoID(self, mock_jsonRequest):
         Datadog('abc').notify(title='test title', message='test message', id='', tags=['environment:test'], priority='normal', alert_type='info')
         self.assertEquals(mock_jsonRequest.call_count, 0)
+
+    def _createJsonRequestWrapper(self, marathonurl='http://localhost:1'):
+        appurl = '%s/v2/apps/myproduct/myservice' % marathonurl
+
+        def wrapper(url, method='GET', data=None, *args, **kwargs):
+            if url.startswith('file:'):
+                return jsonRequest(url, data, *args, **kwargs)
+            if url == appurl and method == 'PUT' and data:
+                return {}
+            if url == appurl and method == 'GET':
+                return {'app': {}}
+            return None
+        return wrapper
+
+    def testDefaultTags(self):
+        with patch('lighter.util.jsonRequest', wraps=self._createJsonRequestWrapper()) as mock_jsonRequest:
+            lighter.deploy('http://localhost:1/', filenames=['src/resources/yaml/integration/datadog-default-tags.yml'])
+            mock_jsonRequest.assert_any_call('https://app.datadoghq.com/api/v1/events?api_key=abc', data=ANY, method='POST')
+
+            expected = [
+                'environment:default',
+                u'service:/myproduct/myservice',
+                'source:lighter']
+            self.assertEquals(expected, mock_jsonRequest.call_args[1]['data']['tags'])
+
+    def testConfiguredTags(self):
+        with patch('lighter.util.jsonRequest', wraps=self._createJsonRequestWrapper()) as mock_jsonRequest:
+            lighter.deploy('http://localhost:1/', filenames=['src/resources/yaml/integration/datadog-config-tags.yml'])
+            mock_jsonRequest.assert_any_call('https://app.datadoghq.com/api/v1/events?api_key=abc', data=ANY, method='POST')
+
+            expected = [
+                'environment:default',
+                u'service:/myproduct/myservice',
+                'somekey:someval',
+                'anotherkey:anotherval',
+                'justakey',
+                'source:lighter']
+            self.assertEquals(expected, mock_jsonRequest.call_args[1]['data']['tags'])

--- a/src/resources/yaml/integration/datadog-config-tags.yml
+++ b/src/resources/yaml/integration/datadog-config-tags.yml
@@ -1,0 +1,19 @@
+maven:
+  groupid: 'com.meltwater'
+  artifactid: 'myservice'
+  version: '[1.0.0,1.1.0)'
+override:
+  cpus: 1.0
+  env:
+    DATABASE: 'database:3306'
+variables:
+  avar: '123'
+  bvar: '%{avar}'
+  cvar: '%{avar}'
+
+datadog:
+  token: 'abc'
+  tags: 
+    - somekey:someval
+    - anotherkey:anotherval
+    - justakey

--- a/src/resources/yaml/integration/datadog-default-tags.yml
+++ b/src/resources/yaml/integration/datadog-default-tags.yml
@@ -1,0 +1,15 @@
+maven:
+  groupid: 'com.meltwater'
+  artifactid: 'myservice'
+  version: '[1.0.0,1.1.0)'
+override:
+  cpus: 1.0
+  env:
+    DATABASE: 'database:3306'
+variables:
+  avar: '123'
+  bvar: '%{avar}'
+  cvar: '%{avar}'
+
+datadog:
+  token: 'abc'


### PR DESCRIPTION
* Added source:lighter default tag to allow filtering for events from Lighter
* Support for user defined tags from yaml files, for example

```
datadog:
  tags:
    - subsystem:something
```
