### PR TITLE
Switched to common event metric

### DIFF
--- a/src/lighter/datadog.py
+++ b/src/lighter/datadog.py
@@ -19,9 +19,10 @@ class Datadog(object):
 
         logging.debug("Sending Datadog deployment metric: %s", message)
         self._call('/api/v1/series', {'series': [{
-            'metric': 'lighter.deployments',
+            'metric': 'datadog.events',
             'points': [[now, 1]],
-            'tags': merged_tags
+            'type': 'count',
+            'tags': merged_tags + ['status:'+alert_type]
         }]})
 
         logging.debug("Sending Datadog event: %s", message)

--- a/src/lighter/test/datadog_test.py
+++ b/src/lighter/test/datadog_test.py
@@ -102,8 +102,9 @@ class DatadogTest(unittest.TestCase):
                 'anotherkey:anotherval',
                 'justakey',
                 'source:lighter',
-                'type:change']
+                'type:change',
+                'status:success']
             data = mock_jsonRequest.call_args_list[-2][1]['data']['series'][0]
-            self.assertEquals('lighter.deployments', data['metric'])
+            self.assertEquals('datadog.events', data['metric'])
             self.assertEquals(1, data['points'][0][1])
             self.assertEquals(tags, data['tags'])


### PR DESCRIPTION
* Switched to event metric since summing different series doesn't work, but it can be done using tags to separate the different event sources
* Changed metric type to `count` since the default `gauge` is incorrect for this use case
* Added event status to metric for filtering purposes
