### PR TITLE
Added profile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ optional arguments:
   -v, --verbose         Increase logging verbosity [default: False]
   -t TARGETDIR, --targetdir TARGETDIR
                         Directory to output rendered config files
+  -p PROFILES, --profile PROFILES
+                        Extra profile files to be merged with service
+                        definitions.
++ '[' -e /tmp/lighter ']'
 ```
 
 ### Deploy Command
@@ -58,6 +62,7 @@ Given a directory structure like
 ```
 config-repo/
 |   globals.yml
+|   myprofile.yml 
 └─ production/
 |   |   globals.yml
 |   |   myfrontend.yml
@@ -70,9 +75,9 @@ config-repo/
     |   myfrontend.yml
 ```
 
-Running `lighter deploy staging/myfrontend.yml` will
+Running `lighter deploy -p myprofile.yml staging/myfrontend.yml` will
 
-* Merge *myfrontend.yml* with environment defaults from *config-repo/staging/globals.yml* and *config-repo/globals.yml*
+* Merge *myfrontend.yml* with environment defaults from *config-repo/staging/globals.yml* and *config-repo/globals.yml* and *myprofile.yml*
 * Fetch the *json* template for this service and version from the Maven repository
 * Expand the *json* template with variables and overrides from the *yml* files
 * Post the resulting *json* configuration into Marathon

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ optional arguments:
   -t TARGETDIR, --targetdir TARGETDIR
                         Directory to output rendered config files
   -p PROFILES, --profile PROFILES
-                        Extra profile files to be merged with service
+                        Extra profile file(s) to be merged with service
                         definitions.
 ```
 
@@ -74,9 +74,9 @@ config-repo/
     |   myfrontend.yml
 ```
 
-Running `lighter deploy -p myprofile.yml staging/myfrontend.yml` will
+Running `lighter deploy -p myprofile1.yml -p myprofile2.yml staging/myfrontend.yml` will
 
-* Merge *myfrontend.yml* with environment defaults from *config-repo/staging/globals.yml* and *config-repo/globals.yml* and *myprofile.yml*
+* Merge *myfrontend.yml* with environment defaults from *config-repo/staging/globals.yml*, *config-repo/globals.yml*, *myprofile1.yml* and *myprofile2.yml*
 * Fetch the *json* template for this service and version from the Maven repository
 * Expand the *json* template with variables and overrides from the *yml* files
 * Post the resulting *json* configuration into Marathon

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ optional arguments:
   -p PROFILES, --profile PROFILES
                         Extra profile files to be merged with service
                         definitions.
-+ '[' -e /tmp/lighter ']'
 ```
 
 ### Deploy Command

--- a/src/lighter/main.py
+++ b/src/lighter/main.py
@@ -187,15 +187,15 @@ def parse_service(filename, targetdir=None, verifySecrets=False, profiles=[]):
 
 def merge_with_profiles(document, profiles):
     for profile in profiles:
-        if not os.path.exists(profile):
-            raise RuntimeError('Could not read profile %s' % profile)
         document = merge_with_service(profile, document)
-
     return document
 
 
-def merge_with_service(candidate, document):
-    with open(candidate, 'r') as fd2:
+def merge_with_service(override_file, document):
+    if not os.path.exists(override_file):
+        raise RuntimeError('Could not read file %s' % override_file)
+
+    with open(override_file, 'r') as fd2:
         document = util.merge(yaml.load(fd2), document)
     return document
 

--- a/src/lighter/main.py
+++ b/src/lighter/main.py
@@ -301,6 +301,7 @@ def deploy(marathonurl, filenames, noop=False, force=False, targetdir=None, prof
 def verify(filenames, targetdir=None, verifySecrets=False, profiles=[]):
     parse_services(filenames, targetdir, verifySecrets, profiles)
 
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         prog='lighter',

--- a/src/lighter/main.py
+++ b/src/lighter/main.py
@@ -95,11 +95,9 @@ def process_env(filename, verifySecrets, env):
 
     return result
 
-def parse_service(filename, targetdir=None, verifySecrets=False, profiles=None):
-    if profiles is None:
-        profiles = []
-
+def parse_service(filename, targetdir=None, verifySecrets=False, profiles=[]):
     logging.info("Processing %s", filename)
+    # Start from a service section if it exists
     with open(filename, 'r') as fd:
         try:
             document = yaml.load(fd)
@@ -125,7 +123,6 @@ def parse_service(filename, targetdir=None, verifySecrets=False, profiles=None):
     # Replace variables in entire document
     document = util.replace(document, variables, raiseError=False, escapeVar=False)
 
-    # Start from a service section if it exists
     config = document.get('service', {})
 
     # Allow resolving version/uniqueVersion variables from docker registry
@@ -190,12 +187,10 @@ def parse_service(filename, targetdir=None, verifySecrets=False, profiles=None):
 
 def merge_with_profiles(document, profiles):
     for profile in profiles:
-        if os.path.exists(profile):
-            document = merge_with_service(profile, document)
-        else:
-            raise RuntimeError('Could not find profile file: %s' % profile)
+        if not os.path.exists(profile):
+            raise RuntimeError('Could not read profile %s' % profile)
+        document = merge_with_service(profile, document)
 
-            # Start from a service section if it exists
     return document
 
 

--- a/src/lighter/test/deploy_test.py
+++ b/src/lighter/test/deploy_test.py
@@ -5,12 +5,17 @@ from mock import patch, Mock
 import lighter.main as lighter
 from lighter.util import jsonRequest
 
+PROFILE_2 = 'src/resources/yaml/myprofile2.yml'
+
+PROFILE_1 = 'src/resources/yaml/myprofile1.yml'
+
+
 class DeployTest(unittest.TestCase):
     def setUp(self):
         self._called = False
 
     def testParseService(self):
-        service = lighter.parse_service('src/resources/yaml/staging/myservice.yml')
+        service = lighter.parse_service('src/resources/yaml/staging/myservice.yml', profiles=[PROFILE_1, PROFILE_2])
         self.assertEquals(service.document['hipchat']['token'], 'abc123')
         self.assertEquals(sorted(service.document['hipchat']['rooms']), ['123', '456', '456', '789'])
         self.assertEquals(service.environment, 'staging')
@@ -172,7 +177,7 @@ class DeployTest(unittest.TestCase):
             self.fail('Expected ValueError')
 
     def testParseNoMavenService(self):
-        service = lighter.parse_service('src/resources/yaml/staging/myservice-nomaven.yml')
+        service = lighter.parse_service('src/resources/yaml/staging/myservice-nomaven.yml', profiles=[PROFILE_1, PROFILE_2])
         self.assertEquals(service.document['hipchat']['token'], 'abc123')
         self.assertEquals(service.config['id'], '/myproduct/myservice-nomaven')
         self.assertEquals(service.config['instances'], 1)

--- a/src/lighter/test/maven_test.py
+++ b/src/lighter/test/maven_test.py
@@ -41,7 +41,7 @@ class MavenTest(unittest.TestCase):
 
     def testSelectVersionLatest(self):
         resolver = maven.ArtifactResolver('file:./src/resources/repository/', 'com.meltwater', 'myservice')
-        
+
         def select(expression, versions):
             return resolver.selectVersion(expression, versions)
 

--- a/src/lighter/test/maven_test.py
+++ b/src/lighter/test/maven_test.py
@@ -12,6 +12,7 @@ class MavenTest(unittest.TestCase):
 
     def testSelectVersionInclusive(self):
         resolver = maven.ArtifactResolver('file:./src/resources/repository/', 'com.meltwater', 'myservice')
+
         def select(expression, versions):
             return resolver.selectVersion(expression, versions)
 
@@ -22,6 +23,7 @@ class MavenTest(unittest.TestCase):
 
     def testSelectVersionExclusive(self):
         resolver = maven.ArtifactResolver('file:./src/resources/repository/', 'com.meltwater', 'myservice')
+
         def select(expression, versions):
             return resolver.selectVersion(expression, versions)
 
@@ -39,6 +41,7 @@ class MavenTest(unittest.TestCase):
 
     def testSelectVersionLatest(self):
         resolver = maven.ArtifactResolver('file:./src/resources/repository/', 'com.meltwater', 'myservice')
+        
         def select(expression, versions):
             return resolver.selectVersion(expression, versions)
 

--- a/src/resources/yaml/globals.yml
+++ b/src/resources/yaml/globals.yml
@@ -1,13 +1,7 @@
 maven:
   repository: 'file:./src/resources/repository/'
-hipchat:
-  token: 'abc123'
-  rooms:
-    - '123'
 variables:
   rabbitmq.url: amqp://localhost:5672
-newrelic:
-  token: 'i_am_an_api_token'
 docker:
   registries:
     'authregistrywithport:5000':

--- a/src/resources/yaml/myprofile1.yml
+++ b/src/resources/yaml/myprofile1.yml
@@ -1,0 +1,4 @@
+hipchat:
+  token: 'abc123'
+  rooms:
+    - '123'

--- a/src/resources/yaml/myprofile2.yml
+++ b/src/resources/yaml/myprofile2.yml
@@ -1,0 +1,2 @@
+newrelic:
+  token: 'i_am_an_api_token'


### PR DESCRIPTION
In our setup we don't have different paths for different environments. So far, we've relied on environment variables to configure the different environments, but this only takes us so far.

The --profile option will allow us to have more complex configuration differences between environments, without having to duplicate the service definitions.