### PR TITLE
Dockerfile and maintainability cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
-FROM alpine:latest
+FROM alpine:3.7
 
-RUN apk -U add ca-certificates python py-yaml py-pip
-RUN pip install mock
+RUN apk -U add ca-certificates python py-yaml py-pip gcc libffi-dev musl-dev \
+               python-dev make
 
-ADD src/ /src/
-ADD lighter /
+ADD lighter requirements.txt /app/
+RUN pip install -r /app/requirements.txt
+
+ADD src/ /app/src/
+ADD lighter test common.sh setup.cfg /app/
 
 # Run unit tests
-ADD test /
-RUN /test
+RUN /app/test
 
 # Expect config directory tree to be mounted into /site
 VOLUME /site
 WORKDIR /site
 
-ENTRYPOINT ["/lighter"]
+ENTRYPOINT ["/app/lighter"]

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,10 @@ set -e -x
 . ./common.sh
 
 # Build the standalone binary
-pyinstaller --hidden-import=cffi --hidden-import=packaging --hidden-import=packaging.version --hidden-import=packaging.specifiers --onefile "--name=lighter-$(uname -s)-$(uname -m)" "--additional-hooks-dir=`dirname $0`/src/hooks" src/lighter/main.py
+pyinstaller --hidden-import=cffi \
+            --hidden-import=packaging \
+            --hidden-import=packaging.version \
+            --hidden-import=packaging.specifiers \
+            --onefile "--name=lighter-$(uname -s)-$(uname -m)" \
+            --additional-hooks-dir="`dirname $0`/src/hooks" \
+            src/lighter/main.py

--- a/common.sh
+++ b/common.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Copied from https://github.com/pyca/cryptography/blob/master/.travis/run.sh
-set -e -x
+set -e
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
     # initialize our pyenv

--- a/lighter
+++ b/lighter
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 . "`dirname $0`/common.sh"
 

--- a/lighter
+++ b/lighter
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e -x
+set -e
 . "`dirname $0`/common.sh"
 
 export PYTHONPATH=".:`dirname $0`/src"

--- a/test
+++ b/test
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -e -x
+#!/bin/sh
+set -e
 . ./common.sh
 
 cd "`dirname $0`"

--- a/test
+++ b/test
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-. ./common.sh
+. `dirname $0`/common.sh
 
 cd "`dirname $0`"
 export PYTHONPATH=".:`pwd`/src"


### PR DESCRIPTION
## Motivation

In response to my own issue #56 as well as your own comments in #39 I wanted to give my zero-python knowledge a shot and hope those bits and pieces are in handy for you, too.

If there's anything missing or you think that should change (else, or too), please tell me.

## My overall changelog of this PR includes:

* major Dockerfile revamp
  * fixiate alpine base image from `latest` to `3.7` to avoid accidental incompats in the future
  * adds necessary system dependencies (via apk)
  * isolate application code into /app instead of system root (/)
  * ensure Python app-level dependencies are present (pip install -r ...)
* don't hardcode to bash but use sh instead (alpine doesn't provide bash)
* fixes relative path to common.sh in test shell script
* build.sh: improve readability by respecting line width
* drop hard-coded debugging prints to shell scripts

Looking forward,
Christian.